### PR TITLE
[FIX] Product card bottom overflow

### DIFF
--- a/lib/src/presentation/screens/product_list_screen.dart
+++ b/lib/src/presentation/screens/product_list_screen.dart
@@ -38,7 +38,7 @@ class ProductListScreen extends StatelessWidget {
               crossAxisCount: 2, 
               crossAxisSpacing: 10,
               mainAxisSpacing: 10,
-              childAspectRatio: 0.75,
+              childAspectRatio: 0.6,
             ),
             padding: const EdgeInsets.all(10),
             itemCount: products.length,


### PR DESCRIPTION
Ajusté un poco el valor del parámetro `childAspectRatio` para solucionar el bottom overflow

Antes | Después
--- | ---
<img width="300" src="https://github.com/user-attachments/assets/e8d9b130-87a0-4140-950a-a75bfdefc13f"/> | <img width="300" src="https://github.com/user-attachments/assets/80ec09de-6554-4564-a4ee-a7954ed82c89"/>